### PR TITLE
add option to allow a wrapperProxy to be enabled by default

### DIFF
--- a/src/__tests__/default-enabled.js
+++ b/src/__tests__/default-enabled.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { mount } from "enzyme";
+import createWrapperProxy from "../";
+import { createLinkedList } from "react-cosmos-shared";
+
+const WrapperComponent = ({ children }) => <div>{children}</div>;
+const Component = () => <span>__COMPONENT_MOCK__</span>;
+
+const renderProxy = proxyOptions => fixtureOptions => {
+  const NextProxy = props => {
+    const { value: P, next } = props.nextProxy;
+
+    return <P {...props} nextProxy={next()} />;
+  };
+
+  const LastProxy = ({ fixture: { component: C, props } }) => <C {...props} />;
+
+  const WrapperProxy = createWrapperProxy({
+    component: WrapperComponent,
+    ...proxyOptions
+  })
+
+  return mount(
+    <WrapperProxy
+      nextProxy={createLinkedList([ NextProxy, LastProxy ])}
+      fixture={fixtureOptions}
+      onComponentRef={jest.fn()}
+      onFixtureUpdate={jest.fn()}
+    />
+  );
+};
+
+describe("defaultEnabled", () => {
+  it("Should wrap a component when `defaultEnabled` is true", () => {
+    const proxyOptions = { fixtureKey: "wrapper", defaultEnabled: true };
+
+    const fixtureOptions = { component: Component };
+
+    const wrapper = renderProxy(proxyOptions)(fixtureOptions);
+
+    expect(wrapper.find(WrapperComponent)).toHaveLength(1);
+  });
+
+  it("Should not wrap a component when `defaultEnabled` is falsey", () => {
+    expect(
+      renderProxy({ fixtureKey: "wrapper" })({ component: Component }).find(WrapperComponent)
+    ).toHaveLength(0);
+
+    expect(
+      renderProxy({ fixtureKey: "wrapper", defaultEnabled: null })({ component: Component }).find(WrapperComponent)
+    ).toHaveLength(0);
+
+    expect(
+      renderProxy({ fixtureKey: "wrapper", defaultEnabled: undefined })({ component: Component }).find(WrapperComponent)
+    ).toHaveLength(0);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,15 @@ const HOCPropsProxy = props => {
   );
 };
 
-export default ({ component: Component, props, fixtureKey, hoc }) =>
-  function WrapperProxy({ nextProxy, ...nextProps }) {
+export default ({
+  component: Component,
+  props,
+  fixtureKey,
+  hoc,
+  defaultEnabled = false
+}) => function WrapperProxy({ nextProxy, ...nextProps }) {
     const fixtureProps = nextProps.fixture[fixtureKey];
-    const fixtureEnabled = !!fixtureProps;
+    const fixtureEnabled = defaultEnabled || !!fixtureProps;
 
     if (fixtureEnabled && hoc) {
       const HOComponent = fixtureProps[Symbol.iterator]


### PR DESCRIPTION
This is especially handy when using a library that allows for theming (e.g. Material UI), in which one could expect to want all components wrapped by default.